### PR TITLE
chore(codex): share project skills with Claude Code

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills


### PR DESCRIPTION
## Summary

- Add `.agents/skills` as a relative symlink to `.claude/skills` so Codex discovers the existing project skills and both tools use the same source files.

## Notes for review

Verified that the link resolves to the existing `docs-site/SKILL.md`. This change contains only the symlink; no application code changes.

<details>
<summary>🇷🇺 Кратко</summary>

Добавлена относительная ссылка `.agents/skills` на `.claude/skills`: Codex обнаруживает проектные скиллы, а оба инструмента используют одни и те же исходные файлы.

</details>
